### PR TITLE
增加 raw interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 /vendor/
+.phpunit

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-C:30:"PHPUnit\Runner\TestResultCache":288:{a:2:{s:7:"defects";a:1:{s:49:"Mix\Tests\Database\BasePdoTest::testRawParamsBind";i:3;}s:5:"times";a:3:{s:39:"Mix\Tests\Database\BasePdoTest::testRaw";d:0.002;s:47:"Mix\Tests\Database\BasePdoTest::testRawFunction";d:0.001;s:49:"Mix\Tests\Database\BasePdoTest::testRawParamsBind";d:0.006;}}}

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+C:30:"PHPUnit\Runner\TestResultCache":288:{a:2:{s:7:"defects";a:1:{s:49:"Mix\Tests\Database\BasePdoTest::testRawParamsBind";i:3;}s:5:"times";a:3:{s:39:"Mix\Tests\Database\BasePdoTest::testRaw";d:0.002;s:47:"Mix\Tests\Database\BasePdoTest::testRawFunction";d:0.001;s:49:"Mix\Tests\Database\BasePdoTest::testRawParamsBind";d:0.006;}}}

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,14 @@
     "psr-4": {
       "Mix\\Database\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Mix\\Tests\\Database\\": "tests/Cases"
+    }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^8",
+    "mix/framework": "dev-master"
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+>
+    <testsuites>
+        <testsuite  name="Application Test Suite">
+            <directory suffix="Test.php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <!--<directory suffix="Test.php">src/</directory>-->
+        </whitelist>
+    </filter>
+    <php>
+        <const name="PHPUNIT_RUNNING" value="true"/>
+    </php>
+</phpunit>

--- a/src/Base/PDOConnection.php
+++ b/src/Base/PDOConnection.php
@@ -4,6 +4,7 @@ namespace Mix\Database\Base;
 
 use Mix\Core\Component\AbstractComponent;
 use Mix\Database\PDOConnectionInterface;
+use Mix\Database\Query\Expression;
 
 /**
  * Class PDOConnection
@@ -202,6 +203,32 @@ class PDOConnection extends AbstractComponent implements PDOConnectionInterface
         return $this;
     }
 
+
+    /**
+     * 返回当前PDO连接是否在事务内（在事务内的连接回池会造成下次开启事务产生错误）
+     *
+     * @return bool
+     */
+    public function inTransaction()
+    {
+        /** @var  $Pdo \PDO */
+        $Pdo = $this->_pdo;
+
+        return (bool)($Pdo ? $Pdo->inTransaction() : false);
+    }
+
+    /**
+     * 返回一个RawQuery对象，对象的值将不经过参数绑定，直接解释为SQL的一部分，适合传递数据库原生函数
+     *
+     * @param $value
+     *
+     * @return \Mix\Database\Query\Expression
+     */
+    public static function raw($value)
+    {
+        return new Expression($value);
+    }
+
     /**
      * 绑定数组参数
      * @param $sql
@@ -248,14 +275,31 @@ class PDOConnection extends AbstractComponent implements PDOConnectionInterface
         $this->autoConnect();
         // 准备与参数绑定
         if (!empty($this->_params)) {
+            foreach ($this->_params as $key => $item) {
+                if ($item instanceof Expression) {
+                    unset($this->_params[$key]);
+                    $key = substr($key, 0, 1) == ':' ? $key : ":{$key}";
+                    $this->_sql = str_replace($key, $item->getValue(), $this->_sql);
+                }
+            }
             // 有参数
-            list($sql, $params) = self::bindArrayParams($this->_sql, $this->_params);
+            list($sql, $params) = static::bindArrayParams($this->_sql, $this->_params);
             $this->_pdoStatement   = $this->_pdo->prepare($sql);
             $this->_sqlPrepareData = [$sql, $params, []]; // 必须在 bindParam 前，才能避免类型被转换
             foreach ($params as $key => &$value) {
                 $this->_pdoStatement->bindParam($key, $value);
             }
         } elseif (!empty($this->_values)) {
+            foreach ($this->_values as $key => $value) {
+                if ($value instanceof Expression) {
+                    $needle = '?';
+                    if (($pos = strpos($this->_sql, $needle)) !== false) {
+                        if ($this->_sql = substr_replace($this->_sql, $value->getValue(), $pos, strlen($needle))) {
+                            unset($this->_values[$key]);
+                        }
+                    };
+                }
+            }
             // 批量插入
             $this->_pdoStatement   = $this->_pdo->prepare($this->_sql);
             $this->_sqlPrepareData = [$this->_sql, [], $this->_values];

--- a/src/Base/PDOConnection.php
+++ b/src/Base/PDOConnection.php
@@ -278,7 +278,7 @@ class PDOConnection extends AbstractComponent implements PDOConnectionInterface
             foreach ($this->_params as $key => $item) {
                 if ($item instanceof Expression) {
                     unset($this->_params[$key]);
-                    $key = substr($key, 0, 1) == ':' ? $key : ":{$key}";
+                    $key        = substr($key, 0, 1) == ':' ? $key : ":{$key}";
                     $this->_sql = str_replace($key, $item->getValue(), $this->_sql);
                 }
             }

--- a/src/Persistent/PDOConnection.php
+++ b/src/Persistent/PDOConnection.php
@@ -96,7 +96,7 @@ class PDOConnection extends \Mix\Database\Base\PDOConnection
             // 执行父类方法
             return call_user_func_array("parent::{$name}", $arguments);
         } catch (\Throwable $e) {
-            if (self::isDisconnectException($e)) {
+            if (static::isDisconnectException($e)) {
                 // 断开连接异常处理
                 $this->reconnect();
                 // 重新执行方法

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author ihipop@gmail.com @ 19-3-28 上午10:36 For mix-v2.
+ */
+
+namespace Mix\Database\Query;
+
+class Expression
+{
+
+    /**
+     * The value of the expression.
+     *
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * Create a new raw query expression.
+     *
+     * @param  mixed $value
+     *
+     * @return void
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string)$this->getValue();
+    }
+}

--- a/tests/Cases/AbstractBaseTestCase.php
+++ b/tests/Cases/AbstractBaseTestCase.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @author ihipop@gmail.com @ 19-4-1 下午6:35 For mix-v2.
+ */
+
+namespace Mix\Tests\Database;
+
+use PHPUnit\Framework\TestCase;
+
+abstract  class AbstractBaseTestCase extends TestCase
+{
+  
+
+}

--- a/tests/Cases/BasePdoTest.php
+++ b/tests/Cases/BasePdoTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author ihipop@gmail.com @ 19-4-1 下午6:29 For mix-v2.
+ */
+namespace  Mix\Tests\Database;
+use Mix\Database\Base\PDOConnection;
+use Mix\Database\Query\Expression;
+
+class BasePdoTest extends AbstractBaseTestCase
+{
+
+    public function testRawFunction(){
+        $expression = PDOConnection::raw('uuid()');
+        $this->assertInstanceOf(Expression::class,$expression);
+        $this->assertEquals('uuid()',$expression);
+    }
+
+//    public function testRawParamsBind(){
+//        $pdo = new PDOConnection([
+//            'dsn'=>'mysql:host=127.0.0.1;port=3306;charset=utf8mb4;dbname=test_db',
+//            'username'=>'root',
+//            'password'=>''
+//        ]);//@TODO use docker to test real case
+//
+//        $pdo->insert('test_table', ['id' => PDOConnection::raw('uuid()')])->execute();//uuid()可换成一些自定义 函数 存储过程调用等
+//        $this->assertEquals($pdo->getRawSql(),'INSERT INTO `test_table` (`id`) VALUES (uuid())');
+//    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+define('TEST_ROOT', __DIR__);
+include __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
使得如下语法成为可能，可进行任意Mysql原生函数、存储过程调用
```php
$ret = $pdo->createCommand('select :uuid')->bindParams([
                'uuid'=>$pdo::raw('uuid()')
            ])->queryAll();
$ret = $pdo->batchInsert('test_1',[
                ['created_at'=>$pdo::raw('CURRENT_TIMESTAMP() '),'test'=>$pdo::raw('uuid()')],
                ['created_at'=>$pdo::raw('CURRENT_TIMESTAMP() '),'test'=>$pdo::raw('uuid()')]
            ])->execute();
```